### PR TITLE
feat: add envPath for target folder of generating env.js

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -78,6 +78,7 @@ Main param description
 | bucketName                        |     Required      |              | Bucket name, if you don't add the AppId suffix, it will be added automatically for you, capital letters are not allowed |
 | protocol                          |     Optional      |    https     | Https or http                                                                                                           |
 | env                               |     Optional      |              | Environment variables to include in a 'env.js' file with your uploaded code.                                            |
+| envPath                           |     Optional      |              | The generate env file folder of your website project. Defaults to current working directory.                            |
 | [cors](#cors-param-description)   |     Optional      |              | Cross-Origin Resource Sharing                                                                                           |
 | [hosts](#hosts-param-description) |     Optional      |              | Add domain                                                                                                              |
 

--- a/serverless.js
+++ b/serverless.js
@@ -192,6 +192,9 @@ class Website extends Component {
     if (inputs.code.src) {
       inputs.code.src = path.join(inputs.code.root, inputs.code.src)
     }
+    if (inputs.code.envPath) {
+      inputs.code.envPath = path.join(inputs.code.root, inputs.code.envPath)
+    }
     inputs.region = inputs.region || 'ap-guangzhou'
     inputs.bucketName = this.state.bucketName || inputs.bucketName || this.context.resourceId()
     if (!this.confirmEnding(inputs.bucketName, this.context.credentials.tencent.AppId)) {
@@ -245,7 +248,8 @@ class Website extends Component {
     )
 
     // Build environment variables
-    if (inputs.env && Object.keys(inputs.env).length && inputs.code.root) {
+    const envPath = inputs.code.envPath || inputs.code.root
+    if (Object.keys(inputs.env).length && envPath) {
       this.context.status(`Bundling environment variables`)
       this.context.debug(`Bundling website environment variables.`)
       let script = 'window.env = {};\n'
@@ -254,7 +258,7 @@ class Website extends Component {
         // eslint-disable-line
         script += `window.env.${e} = ${JSON.stringify(inputs.env[e])};\n` // eslint-disable-line
       }
-      const envFilePath = path.join(inputs.code.root, 'env.js')
+      const envFilePath = path.join(envPath, 'env.js')
       await utils.writeFile(envFilePath, script)
       this.context.debug(`Website env written to file ${envFilePath}.`)
     }


### PR DESCRIPTION
Now  `env.js` is always generated in  `inputs.code.root`, but some project want to generated to target folder, same to https://github.com/serverless-components/website/pull/26